### PR TITLE
Add k8s file for forwarder

### DIFF
--- a/k8s/forwarder/forwarder.yml
+++ b/k8s/forwarder/forwarder.yml
@@ -20,7 +20,7 @@ spec:
             - name: REMOTE_API_URL
               value: http://second_api:18070/v2.0
             - name: METRICS_TO_FORWARD
+            - name: METRICS_TO_FORWARD
               value: "
-  - name: kubernetes.node.allocatable.cpu_agg\n
-  - name: cpu.total_time_sec_agg\n
-"
+              - name: kubernetes.node.allocatable.cpu_agg\n
+              - name: cpu.total_time_sec_agg\n"

--- a/k8s/forwarder/forwarder.yml
+++ b/k8s/forwarder/forwarder.yml
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: forwarder
+  namespace: monitoring
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: forwarder
+    spec:
+      containers:
+        - name: forwarder
+          image: craigbryant/forwarder:latest
+          imagePullPolicy: Always
+          env:
+            - name: MONASCA_PROJECT_ID
+              value: 3564760a3dd44ae9bd6618d442fd758c
+            - name: REMOTE_API_URL
+              value: http://second_api:18070/v2.0
+            - name: METRICS_TO_FORWARD
+              value: "
+  - name: kubernetes.node.allocatable.cpu_agg\n
+  - name: cpu.total_time_sec_agg\n
+"

--- a/monasca-api-python/README.md
+++ b/monasca-api-python/README.md
@@ -64,26 +64,30 @@ Configuration
 
 A number of environment variables can be passed to the container:
 
-| Variable                  | Default       | Description                      |
-|---------------------------|---------------|----------------------------------|
-| `LOG_LEVEL_ROOT`          | `WARN`        | The level of the root logger     |
-| `LOG_LEVEL_CONSOLE`       | `INFO`        | Minimum level for console output |
-| `API_PORT`                | `8070`        | The API's HTTP port              |
-| `KAFKA_URI`               | `kafka:9092`  | The host and port for kafka      |
-| `INFLUX_HOST`             | `influxdb`    | The host for influxdb            |
-| `INFLUX_PORT`             | `8086`        | The port for influxdb            |
-| `INFLUX_USER`             | `mon_api`     | The influx username              |
-| `INFLUX_PASSWORD`         | `password`    | The influx password              |
-| `INFLUX_DB`               | `mon`         | The influx database name         |
-| `MYSQL_HOST`              | `mysql`       | Alarm DB connection string       |
-| `MYSQL_USER`              | `monapi`      | MySQL DB username                |
-| `MYSQL_PASSWORD`          | `password`    | MySQL DB password                |
-| `MYSQL_DB`                | `mon`         | MySQL database name              |
-| `KEYSTONE_IDENTITY_URI`   | `http://keystone:35357` | Keystone identity address |
-| `KEYSTONE_AUTH_URI`       | `http://keystone:5000`  | Keystone auth address     |
-| `KEYSTONE_ADMIN_USER`     | `admin`       | Keystone admin account user      |
-| `KEYSTONE_ADMIN_PASSWORD` | `secretadmin` | Keystone admin account password  |
-| `KEYSTONE_ADMIN_TENANT`   | `admin`       | Keystone admin account tenant    |
+| Variable                     | Default       | Description                      |
+|------------------------------|---------------|----------------------------------|
+| `LOG_LEVEL_ROOT`             | `WARN`        | The level of the root logger     |
+| `LOG_LEVEL_CONSOLE`          | `INFO`        | Minimum level for console output |
+| `API_PORT`                   | `8070`        | The API's HTTP port              |
+| `KAFKA_URI`                  | `kafka:9092`  | The host and port for kafka      |
+| `INFLUX_HOST`                | `influxdb`    | The host for influxdb            |
+| `INFLUX_PORT`                | `8086`        | The port for influxdb            |
+| `INFLUX_USER`                | `mon_api`     | The influx username              |
+| `INFLUX_PASSWORD`            | `password`    | The influx password              |
+| `INFLUX_DB`                  | `mon`         | The influx database name         |
+| `MYSQL_HOST`                 | `mysql`       | Alarm DB connection string       |
+| `MYSQL_USER`                 | `monapi`      | MySQL DB username                |
+| `MYSQL_PASSWORD`             | `password`    | MySQL DB password                |
+| `MYSQL_DB`                   | `mon`         | MySQL database name              |
+| `KEYSTONE_IDENTITY_URI`      | `http://keystone:35357` | Keystone identity address |
+| `KEYSTONE_AUTH_URI`          | `http://keystone:5000`  | Keystone auth address     |
+| `KEYSTONE_ADMIN_USER`        | `admin`       | Keystone admin account user      |
+| `KEYSTONE_ADMIN_PASSWORD`    | `secretadmin` | Keystone admin account password  |
+| `KEYSTONE_ADMIN_TENANT`      | `admin`       | Keystone admin account tenant    |
+| `AUTHORIZED_ROLES`           | `user, domainuser, domainadmin, monasca-user` | Roles for admin Users |
+| `AGENT_AUTHORIZED_ROLES`     | `monasca-agent` | Roles for metric write only users |
+| `READ_ONLY_AUTHORIZED_ROLES` | `monasca-read-only-user` | Roles for read only users    |
+| `DELEGATE_AUTHORIZED_ROLES`  | `admin`       | Roles allow to read/write cross tenant ID |
 
 If additional values need to be overridden, new config files or jinja2 templates
 can be provided by mounting a replacement on top of the original template:

--- a/monasca-api-python/api-config.conf.j2
+++ b/monasca-api-python/api-config.conf.j2
@@ -23,17 +23,17 @@ notification_method_types = monasca_api.v2.reference.notificationstype:Notificat
 
 [security]
 # The roles that are allowed full access to the API.
-default_authorized_roles = user, domainuser, domainadmin, monasca-user
+default_authorized_roles = {{ AUTHORIZED_ROLES | default('user, domainuser, domainadmin, monasca-user') }}
 
 # The roles that are allowed to only POST metrics to the API. This role would be used by the Monasca Agent.
-agent_authorized_roles = monasca-agent
+agent_authorized_roles = {{ AGENT_AUTHORIZED_ROLES | default('monasca-agent') }}
 
 # The roles that are allowed to only GET metrics from the API.
-read_only_authorized_roles = monasca-read-only-user
+read_only_authorized_roles = {{ READ_ONLY_AUTHORIZED_ROLES | default('monasca-read-only-user') }}
 
 # The roles that are allowed to access the API on behalf of another tenant.
 # For example, a service can POST metrics to another tenant if they are a member of the "delegate" role.
-delegate_authorized_roles = admin
+delegate_authorized_roles = {{ DELEGATE_AUTHORIZED_ROLES | default('admin') }}
 
 [messaging]
 # The message queue driver to use


### PR DESCRIPTION
This is in a subdirectory of k8s and not in monasca-start.sh because the
forwarder isn't part of a normal deploy.