### PR TITLE
Use master branch of monasca-transform

### DIFF
--- a/monasca-transform/Dockerfile
+++ b/monasca-transform/Dockerfile
@@ -11,24 +11,7 @@ RUN set -x && \
 
 RUN set -x && \
     git clone https://github.com/openstack/monasca-transform.git /opt/monasca-transform
-# the following four lines are to get Flint's pod specs into place
-RUN set -x && \
-    cd /opt/monasca-transform && \
-    git fetch https://git.openstack.org/openstack/monasca-transform refs/changes/08/426008/8 && \
-    git checkout FETCH_HEAD
-RUN set -x && \
-    git config --global user.name "Marvin" && \
-    git config --global user.email "david.c.kennedy@hpe.com" && \
-    cd /opt/monasca-transform && \
-    git rebase master && \
-    git branch docker_branch
-RUN set -x && \
-    cd /opt/monasca-transform && \
-    git fetch https://git.openstack.org/openstack/monasca-transform refs/changes/93/427193/4 && \
-    git checkout FETCH_HEAD
-RUN set -x && \
-    cd /opt/monasca-transform && \
-    git rebase docker_branch
+
 RUN set -x && \
     /opt/monasca-transform/scripts/create_zip.sh && \
     cp -f /opt/monasca-transform/scripts/monasca-transform.zip /opt/monasca/transform/lib/. && \


### PR DESCRIPTION
Now that kubernetes metrics aggregation is now available and the late metrics
aggregation timing is merged to master we can simplify the docker image
generation to just use the master branch of monasca-transform.