### PR TITLE
Update Grafana container and add monasca-grafana-app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - mysql
 
   grafana:
-    image: monasca/grafana:4.1.0-pre1-1.0.0
+    image: monasca/grafana:4.0.0-1.1.0
     environment:
       GF_AUTH_BASIC_ENABLED: "false"
       GF_USERS_ALLOW_SIGN_UP: "true"

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -4,6 +4,8 @@ arg GRAFANA_REPO=https://github.com/twc-openstack/grafana.git
 arg GRAFANA_BRANCH=master-keystone
 arg MONASCA_DATASOURCE_REPO=https://git.openstack.org/openstack/monasca-grafana-datasource
 arg MONASCA_DATASOURCE_BRANCH=master
+arg MONASCA_APP_REPO=https://github.com/stackhpc/monasca-grafana-app
+arg MONASCA_APP_BRANCH=master
 
 # To force a rebuild, pass --build-arg REBUILD="$(DATE)" when running
 # `docker build`
@@ -12,13 +14,14 @@ arg REBUILD=1
 env GOPATH=/go GOBIN=/go/bin
 
 run mkdir -p /var/lib/grafana && \
-  mkdir -p $GOPATH/src/github.com/grafana && \
+  mkdir -p $GOPATH/src/github.com/grafana/grafana && \
+  cd $GOPATH/src/github.com/grafana/grafana/ && \
   apk add --no-cache --virtual build-dep \
     nodejs go git musl-dev python make g++ && \
-  git clone \
-    --single-branch --depth=1 -b $GRAFANA_BRANCH \
-    $GRAFANA_REPO $GOPATH/src/github.com/grafana/grafana && \
-  cd $GOPATH/src/github.com/grafana/grafana && \
+  git init && \
+  git remote add origin $GRAFANA_REPO && \
+  git fetch origin $GRAFANA_BRANCH && \
+  git reset --hard FETCH_HEAD && \
   go run build.go setup && go run build.go build && \
   npm install -g yarn && yarn && \
   ./node_modules/.bin/grunt build --force && \
@@ -28,10 +31,19 @@ run mkdir -p /var/lib/grafana && \
   cd / && \
   rm -rf $GOPATH/src/github.com && \
   yarn cache clean && \
-  mkdir -p /var/lib/grafana/plugins/ && \
-  git clone \
-    -b $MONASCA_DATASOURCE_BRANCH \
-    $MONASCA_DATASOURCE_REPO /var/lib/grafana/plugins/monasca-grafana-datasource && \
+  mkdir -p /var/lib/grafana/plugins/monasca-grafana-datasource && \
+  cd /var/lib/grafana/plugins/monasca-grafana-datasource && \
+  git init && \
+  git remote add origin $MONASCA_DATASOURCE_REPO && \
+  git fetch origin $MONASCA_DATASOURCE_BRANCH && \
+  git reset --hard FETCH_HEAD && \
+  cd .. && \
+  mkdir monasca-grafana-app && \
+  cd monasca-grafana-app && \
+  git init && \
+  git remote add origin $MONASCA_APP_REPO && \
+  git fetch origin $MONASCA_APP_BRANCH && \
+  git reset --hard FETCH_HEAD && \
   apk del build-dep && \
   rm -rf /usr/lib/node_modules /usr/lib/go && \
   rm -rf /tmp/npm* /tmp/phantomjs && \

--- a/grafana/build.yml
+++ b/grafana/build.yml
@@ -1,0 +1,5 @@
+repository: monasca/grafana
+variants:
+  - tag: latest
+    aliases:
+      - :4.0.0-1.1.0


### PR DESCRIPTION
The container now includes [monasca-grafana-app](https://github.com/stackhpc/monasca-grafana-app) and builds from [sapcc's grafana branch](https://github.com/sapcc/grafana/tree/grafana4) by default