### PR TITLE
Add support for auto-detecting external Keystone endpoints in k8s

### DIFF
--- a/keystone/Dockerfile
+++ b/keystone/Dockerfile
@@ -8,9 +8,7 @@ run apt-get update && \
 expose 5000 35357
 
 copy supervisord.conf /etc/supervisor/supervisord.conf
-copy keystone-bootstrap.sh /keystone-bootstrap.sh
-copy preload.py /preload.py
-copy start.sh /start.sh
+copy start.sh preload.py k8s_get_service.py keystone-bootstrap.sh /
 copy exit-event-listener.py /usr/local/bin/exit-event-listener
 
 cmd /start.sh

--- a/keystone/README.md
+++ b/keystone/README.md
@@ -46,6 +46,14 @@ A number of environment variables can be provided:
    before proceding with initialization. Default: `24`
  * `KEYSTONE_MYSQL_CONNECT_RETRY_DELAY`: number of seconds to wait after a
    failed connection attempt before retrying. Default: `5`
+ * `KUBERNETES_RESOLVE_PUBLIC_ENDPOINTS`: if set to `true` in a Kubernetes
+   environment, query the Kubernetes API to automatically resolve the `public`
+   and `admin` endpoints for Keystone and `preload.yml` interfaces (see below).
+   Services must have a defined `NodePort` or Ingress controller or the
+   bootstrapping process will fail!
+ * `KEYSTONE_SERVICE_NAME`: the keystone Kubernetes service name, required when
+   `KUBERNETES_RESOLVE_PUBLIC_ENDPOINTS` is set. This service must have a
+   working NodePort or ingress controller!
 
 Minimally, for testing purposes where SQLite is acceptable, no environment
 variables are needed. For use in a Kubernetes environment with MySQL storage,
@@ -130,3 +138,71 @@ endpoints:
 This file will be read on first start by the
 [preload script](https://github.com/hpcloud-mon/monasca-docker/blob/master/keystone/preload.py)
 and will populate Keystone with the configured users, projects, and endpoints.
+
+### Public URLs in Kubernetes
+
+If you are running Keystone and Monasca in a Kubernetes environment, it won't
+be accessible outside the Kubernetes cluster even with the endpoints properly
+exposed using NodePorts or otherwise. This is caused by Keystone's service
+catalog returning URLs (for itself included) that are not accessible outside
+the cluster.
+
+As a workaround, this container can query the Kubernetes API when bootstrapping
+and preloading to set the `public` and `admin` endpoints based on a configured
+Service.
+
+To enable this:
+ * Create a Service using a NodePort for Keystone
+ * Set `KUBERNETES_RESOLVE_PUBLIC_ENDPOINTS=true` in the pod's environment
+ * Set `KEYSTONE_SERVICE_NAME` to the name of the keystone service
+
+When starting the container, check the log output when the container is
+bootstrapping. If all goes well, you should see output like so:
+
+```
+Creating bootstrap credentials...
+2017-04-06 17:49:08.855 58 WARNING keystone.assignment.core [-] Deprecated: Use of the identity driver config to automatically configure the same assignment driver has been deprecated, in the "O" release, the assignment driver will need to be expicitly configured if different than the default (SQL).
+2017-04-06 17:49:09.281 58 INFO keystone.cmd.cli [-] Created domain default
+2017-04-06 17:49:09.346 58 INFO keystone.cmd.cli [req-3d6a822f-7433-4311-b96d-0c7ef8647178 - - - - -] Created project admin
+2017-04-06 17:49:09.375 58 INFO keystone.cmd.cli [req-3d6a822f-7433-4311-b96d-0c7ef8647178 - - - - -] Created user admin
+2017-04-06 17:49:09.379 58 INFO keystone.cmd.cli [req-3d6a822f-7433-4311-b96d-0c7ef8647178 - - - - -] Created Role admin
+2017-04-06 17:49:09.391 58 INFO keystone.cmd.cli [req-3d6a822f-7433-4311-b96d-0c7ef8647178 - - - - -] Granted admin on admin to user admin.
+2017-04-06 17:49:09.398 58 INFO keystone.cmd.cli [req-3d6a822f-7433-4311-b96d-0c7ef8647178 - - - - -] Created Region RegionOne
+2017-04-06 17:49:09.442 58 INFO keystone.cmd.cli [req-3d6a822f-7433-4311-b96d-0c7ef8647178 - - - - -] Created admin endpoint http://192.168.99.100:30353
+2017-04-06 17:49:09.453 58 INFO keystone.cmd.cli [req-3d6a822f-7433-4311-b96d-0c7ef8647178 - - - - -] Created internal endpoint http://172.17.0.5:5000
+2017-04-06 17:49:09.463 58 INFO keystone.cmd.cli [req-3d6a822f-7433-4311-b96d-0c7ef8647178 - - - - -] Created public endpoint http://192.168.99.100:30500
+```
+
+The above is from a minikube environment running
+[monasca-helm](https://github.com/hpcloud-mon/monasca-helm) with Keystone
+NodePorts mapping ports 5000 -> 30500 and 35357 -> 30353. The IP address is
+the address of minikube's VirtualBox VM and is accessible from the host.
+Running `openstack endpoint list` on the host with appropriate environment
+variables set now works and shows accessible public endpoints.
+
+Note that this same functionality can be applied to services in `preload.yml` as
+well. First, take an interfaces block:
+
+```
+interfaces: ['public', 'internal', 'admin']
+```
+
+And expand it out, adding `resolve: true` to endpoints that should be accessible
+from outside the cluster:
+
+```
+interfaces:
+  - name: internal
+    url: http://service-name:1234/v2.0
+  - name: public
+    url: http://service-name:1234/v2.0
+    resolve: true
+  - name: admin
+    url: http://service-name:1234/v2.0
+    resolve: true
+```
+
+When preloading services with `resolve: true` will be looked up via the k8s API
+and the external IP and port will be added to the Keystone catalog rather than
+the listed internal DNS names. Otherr components of the URL will be preserved,
+only the host and port are replaced.

--- a/keystone/build.yml
+++ b/keystone/build.yml
@@ -1,0 +1,5 @@
+repository: monasca/keystone
+variants:
+  - tag: 1.1.0
+    aliases:
+      - :latest

--- a/keystone/k8s_get_service.py
+++ b/keystone/k8s_get_service.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import print_function
+
+import socket
+import sys
+
+import requests
+
+CACERT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+NAMESPACE_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+API_URL = "https://kubernetes.default:443"
+
+
+def read(path):
+    with open(path, 'r') as f:
+        return f.read()
+
+
+CURRENT_POD = socket.gethostname()
+CURRENT_NAMESPACE = read(NAMESPACE_PATH)
+TOKEN = read(TOKEN_PATH)
+
+
+class KubernetesAPIException(Exception):
+    pass
+
+
+def api_get(endpoint):
+    r = requests.get('{}/{}'.format(API_URL, endpoint),
+                     timeout=1000,
+                     headers={'Authorization': 'Bearer {}'.format(TOKEN)},
+                     verify=CACERT_PATH)
+    r.raise_for_status()
+
+    return r.json()
+
+
+def get_node_port(service_name, port=None):
+    svc = api_get('/api/v1/namespaces/{}/services/{}'.format(
+        CURRENT_NAMESPACE, service_name))
+
+    ip = None
+    if svc['spec']['type'] == 'NodePort':
+        lb = svc['status']['loadBalancer']
+
+        if 'ingress' in lb:
+            ip = lb['ingress'][0]['ip']
+
+    if port:
+        if isinstance(port, int) or str(port).isdigit():
+            for port_def in svc['spec']['ports']:
+                if port_def.get('port') == port:
+                    return ip, port_def['nodePort']
+        else:
+            for port_def in svc['spec']['ports']:
+                if port_def.get('name') == port:
+                    return ip, port_def['nodePort']
+    else:
+        for port_def in svc['spec']['ports']:
+            if 'nodePort' in port_def and port_def['nodePort']:
+                return ip, port_def['nodePort']
+
+    raise KubernetesAPIException(
+        'Could not get NodePort from k8s API: service=%s, '
+        'port=%s' % (service_name, port))
+
+
+def get_node_ip():
+    pod = api_get('/api/v1/namespaces/{}/pods/{}'.format(CURRENT_NAMESPACE,
+                                                         CURRENT_POD))
+    return pod['status']['hostIP']
+
+
+def resolve_service(service_name, port=None):
+    ingress_ip, node_port = get_node_port(service_name, port)
+    if ingress_ip is None:
+        # the node ip won't be "correct" for other services but k8s should
+        # direct the traffic where it needs to go
+        # it is not trivial to resolve a service -> pod node IP
+        # (and doesn't make too much sense anyway)
+        # potentially could just grab the master node from
+        # /v1/api/nodes .items[0]
+        ingress_ip = get_node_ip()
+
+    return ingress_ip, node_port
+
+
+def main():
+    if len(sys.argv) not in (2, 3):
+        print('A service name is required', file=sys.stderr)
+        sys.exit(1)
+
+    if len(sys.argv) == 3:
+        port_name = sys.argv[2]
+    else:
+        port_name = None
+
+    ingress_ip, node_port = resolve_service(sys.argv[1], port_name)
+    print('{}:{}'.format(ingress_ip, node_port))
+
+
+if __name__ == '__main__':
+    main()

--- a/keystone/keystone-bootstrap.sh
+++ b/keystone/keystone-bootstrap.sh
@@ -20,6 +20,24 @@ else
     internal_url=${KEYSTONE_INTERNAL_URL:-"http://localhost:5000"}
 fi
 
+if [[ -n "$KUBERNETES_RESOLVE_PUBLIC_ENDPOINTS" ]]; then
+    keystone_service_name=${KEYSTONE_SERVICE_NAME:-"keystone"}
+    service_url=$(python /k8s_get_service.py "${keystone_service_name}" http)
+    if [[ $? -eq 0 ]]; then
+        public_url="http://${service_url}"
+    else
+        echo "ERROR: Failed to get public URL from Kubernetes API!"
+    fi
+
+    service_admin_url=$(python /k8s_get_service.py "${keystone_service_name}" admin)
+    if [[ $? -eq 0 ]]; then
+      admin_url="http://${service_admin_url}"
+    else
+      # not ERROR since this is somewhat less fatal
+      echo "WARNING: Failed to get admin URL from Kubernetes API!"
+    fi
+fi
+
 if [[ -e /db-init ]]; then
     echo "Creating bootstrap credentials..."
     keystone-manage bootstrap \

--- a/keystone/preload.yml
+++ b/keystone/preload.yml
@@ -35,4 +35,12 @@ endpoints:
     type: monitoring
     region: RegionOne
     url: http://monasca:8070/v2.0
-    interfaces: ['public', 'internal', 'admin']
+    interfaces:
+      - name: internal
+        url: http://monasca:8070/v2.0
+      - name: public
+        url: http://monasca:8070/v2.0
+        resolve: true
+      - name: admin
+        url: http://monasca:8070/v2.0
+        resolve: true

--- a/keystone/start.sh
+++ b/keystone/start.sh
@@ -60,6 +60,6 @@ if [[ -e /kill-supervisor ]]; then
     echo "Exiting uncleanly due to bootstrap failure!"
     exit 1
 else
-    echo "Existing cleanly..."
+    echo "Exiting cleanly..."
     exit 0
 fi


### PR DESCRIPTION
This adds new functionality to the Keystone container to allow it to
auto-detect external (public and admin) URLs when creating catalog
entries. This only works in Kubernetes environments with
KUBERNETES_RESOLVE_PUBLIC_ENDPOINTS=true and
KEYSTONE_SERVICE_NAME set to the name of the keystone service. The
end result of this is that Keystone can be used from outside of a
Kubernetes without any routing issues.

Services in preload.yml can also use the new functionality. By adding
`resolve: true` to an 'interfaces:' entry, the service will be looked
up in the Kubernetes API based on the URL and replaced with the
correct publicly-accessible node or ingress IP and port.